### PR TITLE
feat: docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# Dependencies
+node_modules
+
+# Build outputs
+build
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# OS / Editor
+.DS_Store
+.vscode
+.idea
+
+# Git
+.git
+.gitignore
+
+# Docker
+Dockerfile*
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# --- Build stage: compile TypeScript ---
+FROM node:20-alpine AS builder
+WORKDIR /app
+
+COPY package*.json ./
+RUN if [ -f package-lock.json ]; then npm ci; else npm install; fi
+
+COPY tsconfig.json ./
+COPY src ./src
+COPY config.json ./config.json
+RUN npm run build
+
+# --- Runtime stage: smaller, production-only deps ---
+FROM node:20-alpine AS runner
+ENV NODE_ENV=production
+WORKDIR /app
+
+COPY package*.json ./
+RUN if [ -f package-lock.json ]; then npm ci --omit=dev; else npm install --omit=dev; fi
+
+COPY --from=builder /app/build ./build
+COPY config.json ./config.json
+
+COPY manifest.json ./manifest.json
+
+ENV PORT=3400
+EXPOSE 3400
+
+CMD ["node", "build/index.js"]

--- a/config.json
+++ b/config.json
@@ -1,8 +1,7 @@
 {
   "mcp": {
     "name": "kirha-crypto",
-    "version": "1.0.0",
-    "mode": "stdio"
+    "version": "1.0.0"
   },
   "api": {
     "summarization": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  mcp:
+    container_name: kirha-mcp-gateway
+    image: kirha-mcp-gateway:local
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      - NODE_ENV=production
+      - PORT=3400
+      - MODE=http
+      - VERTICAL_ID=crypto
+      - PLAN_MODE_ENABLED=true
+    ports:
+      - "3400:3400"
+    volumes:
+      - ./config.json:/app/config.json:ro
+      - ./manifest.json:/app/manifest.json:ro
+
+  mcp-inspector:
+    image: ghcr.io/modelcontextprotocol/inspector:latest
+    container_name: mcp-inspector
+    ports:
+      - "6274:6274"
+      - "6277:6277"
+    environment:
+      - CLIENT_PORT=6274
+      - SERVER_PORT=6277
+      - MCP_AUTO_OPEN_ENABLED=false
+      - DANGEROUSLY_OMIT_AUTH=true
+    domainname: local

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kirha/mcp-gateway",
-  "version": "0.0.8",
+  "version": "0.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kirha/mcp-gateway",
-      "version": "0.0.8",
+      "version": "0.0.10",
       "license": "ISC",
       "dependencies": {
         "@hono/node-server": "^1.19.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,25 +31,30 @@ function createStatelessServer(config: Config) {
         inputSchema: toolDefinition.inputSchema,
       },
       (input, extra) => {
-        const apiKey = (extra.requestInfo?.headers["x-kirha-api-key"] as string) ?? config.apiKey;
+        const apiKey =
+          (extra.requestInfo?.headers["x-kirha-api-key"] as string) ??
+          config.apiKey;
 
         if (!apiKey) {
           throw new Error("KIRHA_API_KEY is required");
         }
 
         return toolDefinition.handler(input, { ...config, apiKey });
-      },
+      }
     );
   });
 
   return server;
 }
 
-function streamableHTTPTransport(c: Context, options?: StreamableHTTPServerTransportOptions) {
+function streamableHTTPTransport(
+  c: Context,
+  options?: StreamableHTTPServerTransportOptions
+) {
   const transport = new StreamableHTTPServerTransport(
     options ?? {
       sessionIdGenerator: undefined,
-    },
+    }
   );
 
   return Object.assign(transport, {
@@ -71,7 +76,7 @@ function startHttpServer(config: Config) {
       allowMethods: ["GET", "POST", "OPTIONS"],
       allowHeaders: ["Accept", "Content-Type", "x-kirha-api-key"],
       exposeHeaders: ["Content-Type"],
-    }),
+    })
   );
 
   app.get("/health", (c) => {
@@ -95,7 +100,7 @@ function startHttpServer(config: Config) {
       const url = `${protocol}://${address}:${info.port}`;
 
       console.log(`MCP server started on ${url}`);
-    },
+    }
   );
 }
 
@@ -105,8 +110,8 @@ async function startStdioServer(config: Config) {
   await server.connect(transport);
 }
 
-const isHttpMode = config.mcpServer.mode === "http";
-const isStdioMode = config.mcpServer.mode === "stdio";
+const isHttpMode = config.mode === "http";
+const isStdioMode = config.mode === "stdio";
 
 if (isHttpMode) {
   console.log("Start HTTP Mcp server");


### PR DESCRIPTION
Added Dockerfile support by adding :
- Dockerfile
- .dockerignore
- docker-compose.yml (mcp-inspector seems broken, see : https://github.com/modelcontextprotocol/inspector/issues/788)

I also changed how the `mode` is passed : 
- Make more sense to have it as a env variable as `port` is also a env variable
- Easier to configure the service through docker